### PR TITLE
fix: empty value error #26

### DIFF
--- a/custom_components/phyn/devices/pw.py
+++ b/custom_components/phyn/devices/pw.py
@@ -133,7 +133,9 @@ class PhynWaterSensorDevice(PhynDevice):
             if entry['ts'] > item['ts']:
                 item = entry
 
-        self._water_statistics.update(item)
+        if item:
+            self._water_statistics.update(item)
+
         LOGGER.debug("Phyn Water device state: %s", self._device_state)
 
     async def async_setup(self):


### PR DESCRIPTION
Hey, this fixes the error from #26 which prevents the integration from working. For some reason the PW1 devices sometimes return an empty response which was causes the `self._water_statistics.update(item)` command to crash and then seems to stop the whole update process. 

The fix has been working for me for the past few days and I haven't noticed any errors. Let me know know if there is anything else to consider with the fix.