### PR TITLE
Fix: Migrate deprecated service helper imports for HA 2026.8 compatibility

### DIFF
--- a/custom_components/phyn/services.py
+++ b/custom_components/phyn/services.py
@@ -1,20 +1,17 @@
 """Services for the phyn integration"""
 
-import datetime
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
-from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er, entity_platform, service
-from homeassistant.helpers.service import async_extract_referenced_entity_ids
-from homeassistant.util.json import JsonObjectType
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.target import async_extract_referenced_entity_ids, TargetSelection
 
 from .const import CLIENT, DOMAIN, LOGGER
 
 async def phyn_leak_test(service: ServiceCall):
     """Handle the service call."""
-    entity = service.data['entity_id']
-
-    ref = async_extract_referenced_entity_ids(service.hass, service)
+    
+    tgt = TargetSelection(service.data)
+    ref = async_extract_referenced_entity_ids(service.hass, tgt)
     entity_registry = er.async_get(service.hass)
     device_registry = dr.async_get(service.hass)
     


### PR DESCRIPTION
`homeassistant.helpers.service.async_extract_referenced_entity_ids`
was deprecated and removed in HA 2026.8. This breaks the Phyn integration on startup.

Changes made to fix:
1. function was replaced by `homeassistant.helpers.target.async_extract_referenced_entity_ids`
2. this function requires an additional unwrapping of the service call by calling `TargetSelection(service_call)`

Additional changes:
- removed unused imports and variables in this file as well

Testing:
I was able to use my phyn at home in HomeAssistant, component starts correctly, able to see flow rate, all sensors. run of leak test shows leak test sensor transition to running, back to not running. main valve and pressure sensors adjust as well.

closes #63